### PR TITLE
fix: webp image detection

### DIFF
--- a/services/resource/common/mimetype.py
+++ b/services/resource/common/mimetype.py
@@ -9,10 +9,16 @@ def is_svg(buffer: bytes) -> bool:
     head = buffer[:1024].decode("utf-8", errors="ignore").lower()
     return "<svg" in head
 
+
+def is_webp(buffer: bytes) -> bool:
+    return len(buffer) >= 12 and buffer[:4] == b'RIFF' and buffer[8:12] == b'WEBP'
+
+
 def discover_mimetype(buffer: bytes) -> str:
     if is_gltf(buffer):
         return 'model/gltf-binary'
     if is_svg(buffer):
         return 'image/svg+xml'
+    if is_webp(buffer):
+        return 'image/webp'
     return magic.from_buffer(buffer, mime=True)
-


### PR DESCRIPTION
The libmagic database doesn't recognize WebP VP8X (extended format) files. Sometimes this cause some webp images with alpha to not render on the browser.