### PR TITLE
fix: add missing event field in notification test fixtures

### DIFF
--- a/services/resource/tests/api/image/test_image_service.py
+++ b/services/resource/tests/api/image/test_image_service.py
@@ -426,7 +426,8 @@ class TestImageService(unittest.TestCase):
                     'tenant': any_tenant,
                     'library': any_library,
                     'name': any_name,
-                    'progress': progress
+                    'progress': progress,
+                    'event': 'GENERATE_PROGRESS',
                 }
             if invalidate:
                 s['invalidation_urls'] = [

--- a/services/resource/tests/consumer/test_main_worker.py
+++ b/services/resource/tests/consumer/test_main_worker.py
@@ -165,7 +165,8 @@ class TestMainWorker(unittest.TestCase):
             'library': 'any_target',
             'tenant': any_tenant,
             'name': 'any_name',
-            'progress': 0.5
+            'progress': 0.5,
+            'event': 'GENERATE_PROGRESS',
         }
 
         # Common test data

--- a/services/resource/tests/consumer/test_system_consumer.py
+++ b/services/resource/tests/consumer/test_system_consumer.py
@@ -54,7 +54,8 @@ class TestConsumer(unittest.TestCase):
                 'tenant': 'hopara.io',
                 'library': 'any_library',
                 'name': 'any_name',
-                'progress': 0.1
+                'progress': 0.1,
+                'event': 'GENERATE_PROGRESS',
             },
             "type": "copy"
         })


### PR DESCRIPTION
The previous commit made `event` a Required field on ResourceStepNotification. Three existing tests were building notification dicts inline without setting `event` and relied on the removed default. Add `event='GENERATE_PROGRESS'` to preserve the historical behavior the tests were exercising.