### PR TITLE
chore: removing uuid package

### DIFF
--- a/front/packages/components/package.json
+++ b/front/packages/components/package.json
@@ -131,7 +131,6 @@
     "supercluster": "^8.0.1",
     "tsyringe": "^4.10.0",
     "typesafe-actions": "^5.1.0",
-    "uuid": "^9.0.0",
     "vega": "^5.33.0",
     "vega-lite": "^5.1.1"
   },

--- a/front/packages/components/src/action/Action.ts
+++ b/front/packages/components/src/action/Action.ts
@@ -1,6 +1,5 @@
 import {Visible} from '../layer/Visible'
 import {ZoomValue} from '../zoom/ZoomValue'
-import {v4 as uuidv4} from 'uuid'
 import {i18n} from '@hopara/i18n'
 
 export type TemplateString = string
@@ -36,7 +35,7 @@ class BaseAction {
 
   constructor(props?: Partial<BaseAction>) {
     Object.assign(this, props ?? {})
-    this.id = props?.id ?? uuidv4()
+    this.id = props?.id ?? crypto.randomUUID()
     this.title = props?.title ?? i18n('NEW_ACTION')
   }
 }

--- a/front/packages/components/src/action/editor/ActionsEditor.tsx
+++ b/front/packages/components/src/action/editor/ActionsEditor.tsx
@@ -4,7 +4,6 @@ import {Action, ActionType} from '../Action'
 import {ListActionPillButton} from '@hopara/design-system/src/buttons/ListActionPillButton'
 import {i18n} from '@hopara/i18n'
 import {DraggableList, ListItemData} from '@hopara/design-system/src/list'
-import {v4 as uuid} from 'uuid'
 import {Empty} from '@hopara/design-system/src/empty/Empty'
 import {Layer} from '../../layer/Layer'
 import {Icon} from '@hopara/design-system/src/icons/Icon'
@@ -78,7 +77,7 @@ export class ActionsEditor extends PureComponent<Props> {
             sublist={this.props.sublist}
             items={this.props.items.map((item: Action) => {
               return {
-                id: item.id ?? uuid(),
+                id: item.id ?? crypto.randomUUID(),
                 name: item.title,
                 icon: getIconFromActionType(item.type),
               }

--- a/front/packages/components/src/filter/domain/Filter.ts
+++ b/front/packages/components/src/filter/domain/Filter.ts
@@ -1,6 +1,5 @@
  
 import { Data } from '@hopara/encoding'
-import {v4 as uuidv4} from 'uuid'
 import {classToPlain} from 'class-transformer'
 import 'reflect-metadata'
 import {i18n} from '@hopara/i18n'
@@ -27,7 +26,7 @@ export class Filter {
 
   constructor(props?: Partial<Filter>) {
     Object.assign(this, props)
-    this.id = props?.id ?? uuidv4()
+    this.id = props?.id ?? crypto.randomUUID()
     this.data = new Data(this.data ?? {})
     this.values = this.values ?? []
   }

--- a/front/packages/components/src/floor/Floor.ts
+++ b/front/packages/components/src/floor/Floor.ts
@@ -1,5 +1,4 @@
 import {i18n} from '@hopara/i18n'
-import {v4 as uuidv4} from 'uuid'
 import wordsToNumbers from '@hopara/multilingual-number-parser'
 import {naturalCompare} from '@discoveryjs/natural-compare'
 
@@ -60,7 +59,7 @@ export class Floor {
       props = {name: props}
     }
     this.name = props.name ?? i18n('FLOOR_NAME')
-    this.id = props.id ?? uuidv4()
+    this.id = props.id ?? crypto.randomUUID()
     this.acronym = props.acronym ?? getAcronymByName(this.name)
   }
 

--- a/front/packages/components/src/layer/Layer.ts
+++ b/front/packages/components/src/layer/Layer.ts
@@ -11,7 +11,6 @@ import {QueryKey} from '@hopara/dataset/src/query/Queries'
 import {LayerType} from './LayerType'
 import {Details} from '../details/Details'
 import {Actions} from '../action/Actions'
-import {v4 as uuidv4} from 'uuid'
 import {Layers} from './Layers'
 import {isEmpty} from 'lodash'
 import {VisualizationType} from '../visualization/Visualization'
@@ -189,7 +188,7 @@ export class Layer implements QueryHolder {
     Object.assign(this, props)
 
     this.lastModified = new Date()
-    if (!this.id) this.id = uuidv4()
+    if (!this.id) this.id = crypto.randomUUID()
     if (this.data) this.data = new Data(this.data)
     this.children = new Layers(...(this.children ?? []))
   }

--- a/front/packages/components/src/layer/factory/TemplateCompiler.ts
+++ b/front/packages/components/src/layer/factory/TemplateCompiler.ts
@@ -2,7 +2,6 @@ import { isEmpty } from 'lodash'
 import { Layer, PlainLayer } from '../Layer'
 import { LayerTemplate, TemplateForm } from '../template/domain/LayerTemplate'
 import { nullToUndefined } from './NullToUndefined'
-import {v4 as uuidv4} from 'uuid'
 
 export class TemplateCompiler {
   layerTemplates: LayerTemplate[]
@@ -33,7 +32,7 @@ export class TemplateCompiler {
   getIdMap(layerCount: number): Record<string, string> {
     const idMap: Record<string, string> = {}
     for (let i = 0; i < layerCount; i++) {
-      idMap[`{{id#${i}}}`] = uuidv4()
+      idMap[`{{id#${i}}}`] = crypto.randomUUID()
     }
     return idMap
   }

--- a/front/packages/components/src/layer/mutator/LayerMutator.ts
+++ b/front/packages/components/src/layer/mutator/LayerMutator.ts
@@ -13,7 +13,6 @@ import {EncodingAnimation} from '../EncodingAnimation'
 import {LayerFactory} from '../factory/LayerFactory'
 import {Layers} from '../Layers'
 import {i18n} from '@hopara/i18n'
-import {v4 as uuidv4} from 'uuid'
 import {Column} from '@hopara/dataset'
 import {SizeUnits} from '@hopara/encoding/src/size/SizeEncoding'
 import {VisualizationType} from '../../visualization/Visualization'
@@ -244,10 +243,10 @@ export class LayerMutator {
 
   duplicate(layer: Layer) {
     let duplicatedLayer = this.layerFactory.duplicate(layer)
-    duplicatedLayer = this.mutate(duplicatedLayer, {id: uuidv4(), name: `${duplicatedLayer.name} (${i18n('COPY')})`})
+    duplicatedLayer = this.mutate(duplicatedLayer, {id: crypto.randomUUID(), name: `${duplicatedLayer.name} (${i18n('COPY')})`})
     if (duplicatedLayer.hasChildren()) {
       const children = duplicatedLayer.children!.map((child) => this.mutate(child, {
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         parentId: duplicatedLayer.getId(),
       }))
       duplicatedLayer = this.mutate(duplicatedLayer, {children: new Layers(...children)})

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -2863,7 +2863,6 @@ __metadata:
     supercluster: "npm:^8.0.1"
     tsyringe: "npm:^4.10.0"
     typesafe-actions: "npm:^5.1.0"
-    uuid: "npm:^9.0.0"
     vega: "npm:^5.33.0"
     vega-lite: "npm:^5.1.1"
   languageName: unknown


### PR DESCRIPTION
This commit fixes the vulnerability below: 
   ├─ ID: 1116970
   ├─ Issue: uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided
   ├─ URL: https://github.com/advisories/GHSA-w5hq-g745-h8pq
   ├─ Severity: moderate